### PR TITLE
Updated safe_update to be compatible with ruby 3

### DIFF
--- a/exe/safe_update
+++ b/exe/safe_update
@@ -22,5 +22,5 @@ end.parse!
 if options[:version]
   puts "safe_update version #{SafeUpdate::VERSION}"
 else
-  SafeUpdate::Updater.new.run(options)
+  SafeUpdate::Updater.new.run(**options)
 end

--- a/lib/safe_update/version.rb
+++ b/lib/safe_update/version.rb
@@ -1,3 +1,3 @@
 module SafeUpdate
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
Problem:
safe_update library is not compatible with Ruby 3 but we already upgraded to Ruby 3 in murmur

Console errors:
updater.rb is throwing the error: 
`safe_update/updater.rb:13:in `run': wrong number of arguments (given 1, expected 0) (ArgumentError)`

presenter.rb is throwing the error:
`presenter.rb:44:in `print_final_output': undefined method `each' for nil:NilClass (NoMethodError)`

Solution:
Maintain our a version of our own safe_update library

Fixes:
1. Used double splat operator in safe_update.rb
2. Added a check to make sure outdated_gems is not empty